### PR TITLE
Remove redundant mention of "Emacs" in Commentary

### DIFF
--- a/mips-mode.el
+++ b/mips-mode.el
@@ -14,7 +14,7 @@
 ;;
 ;;; Commentary:
 ;;
-;; An Emacs major mode for MIPS Assembly based off [haxor-mode]. Written for the
+;; A major mode for MIPS Assembly based off [haxor-mode]. Written for the
 ;; MIPS Assembly track on exercism.io.
 ;;
 ;;; Code:


### PR DESCRIPTION
All major modes written in elisp are emacs major modes. :-)
