### PR TITLE
Add indentation, code evaluation, custom group

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,15 @@
 
 # mips-mode
 
-An Emacs major mode for MIPS Assembly code, based off [haxor-mode]. Written
-for the [MIPS Assembly track on exercism.io](http://exercism.io/languages/mips).
+An Emacs major mode for MIPS Assembly code, based off [haxor-mode]. Originally
+written for the [MIPS Assembly track on exercism.io](http://exercism.io/languages/mips).
+[MIPS Reference](http://www.cburch.com/cs/330/reading/mips-ref.pdf).
 
-> MIPS Reference Sheet: http://www.cburch.com/cs/330/reading/mips-ref.pdf
+## Features
+
+- Code evaluation with `spim`
+- Syntactic highlighting
+- Syntactic indentation
 
 ## Installation
 
@@ -15,15 +20,20 @@ mips-mode is available on MELPA. To install:
 
 `M-x package-install RET mips-mode`
 
-## Usage
-
-Use `(require 'mips-mode)`, it will set up itself.
-
 Alternatively, for use-package users:
 
 ``` emacs-lisp
 (use-package mips-mode :mode "\\.mips$")
 ```
 
+## Usage
+
+Use `(require 'mips-mode)`; it will set up itself.
+
+## Keybindings
+
+`C-c C-c` evaluates the current buffer in `mips-interpreter`
+
+`C-c C-r` evaluates the current region in `mips-interpreter`
 
 [haxor-mode]: https://github.com/krzysztof-magosa/haxor-mode

--- a/mips-mode.el
+++ b/mips-mode.el
@@ -19,6 +19,13 @@
 ;;
 ;;; Code:
 
+(defgroup mips nil
+  "Major mode for editing MIPS assembly"
+  :prefix "mips-"
+  :group languages
+  :link '(url-link :tag "Github" "https://github.com/hlissner/emacs-mips-mode")
+  :link '(emacs-commentary-link :tag "Commentary" "ng2-mode"))
+
 (defconst mips-keywords
   '(;; instructions
     "add"
@@ -151,6 +158,7 @@
 (defcustom mips-tab-width tab-width
   "Width of a tab for MIPS mode"
   :tag "Tab width"
+  :group 'mips
   :type 'integer)
 
 (defvar mips-map

--- a/mips-mode.el
+++ b/mips-mode.el
@@ -149,7 +149,7 @@
      (,(regexp-opt mips-keywords 'words) . font-lock-keyword-face)
      ;; coprocessor load-store instructions
      ("[sl]wc[1-9]" . font-lock-keyword-face)
-     (,(regexp-opt mips-defs 'words) . font-lock-preprocessor-face)
+     (,(regexp-opt mips-defs) . font-lock-preprocessor-face)
      ;; registers
      ("$\\(f?[0-2][0-9]\\|f?3[01]\\|[ft]?[0-9]\\|[vk][01]\\|a[0-3]\\|s[0-7]\\|[gsf]p\\|ra\\|at\\|zero\\)" . font-lock-type-face)
      ;; ("$\\([a-z0-9]\\{2\\}\\|zero\\)" . font-lock-constant-face)


### PR DESCRIPTION
<TAB> indents lines to the indentation of the last label plus
mips-tab-width.

<backtab> reduces the indentation by mips-tab-width.

These should work with electric-indent-mode as well.

Code evaluation requires a mips interpereter, and only
supports spim at the moment.
