### PR TITLE
Add more instructions, goto-label functions

### DIFF
--- a/mips-mode.el
+++ b/mips-mode.el
@@ -44,6 +44,9 @@
     "mfhi"
     "mflo"
     "mul"
+    "mulu"
+    "mulo"
+    "mulou"
     ;; Bitwise operations
     "not"
     "and"
@@ -61,6 +64,12 @@
     "srlv"
     "srav"
     ;; Comparisons
+    "seq"
+    "sne"
+    "sgt"
+    "sgtu"
+    "sge"
+    "sgeu"
     "slt"
     "sltu"
     "slti"
@@ -80,9 +89,13 @@
     "lh"
     "lhu"
     "lw"
+    "lwl"
+    "lwr"
     "sb"
     "sh"
     "sw"
+    "swl"
+    "swr"
     ;; Concurrent load/store
     "ll"
     "sc"
@@ -100,6 +113,7 @@
     "tltiu"
     "tne"
     "tnei"
+    "rfe"
     ;; Pseudoinstructions
     "b"
     "bal"
@@ -123,6 +137,8 @@
     "la"
     "li"
     "move"
+    "movz"
+    "movn"
     "nop"
     "clear"
     ;; Deprecated branch-hint pseudoinstructions
@@ -161,11 +177,19 @@
     "movz.d"
     "trunc.w.d"
     "trunc.w.s"
+    ;; Conversion
+    "cvt.s.d"
+    "cvt.d.s"
     ;; Math
     "abs.s"
     "abs.d"
     "sqrt.s"
     "sqrt.d"
+    ;; Load-store
+    "l.s"
+    "l.d"
+    "s.s"
+    "s.d"
     ))
 
 (defconst mips-defs

--- a/mips-mode.el
+++ b/mips-mode.el
@@ -219,6 +219,7 @@
     (define-key map (kbd "<backtab>") 'mips-dedent)
     (define-key map (kbd "C-c C-c") 'mips-run-buffer)
     (define-key map (kbd "C-c C-r") 'mips-run-region)
+    (define-key map (kbd "C-c C-l") 'mips-goto-label-at-cursor)
     map)
   "Keymap for mips-mode")
 
@@ -289,6 +290,16 @@ buffer's file"
   (switch-to-buffer-other-window (mips--interpreter-buffer-name))
   (read-only-mode t)
   (help-mode))
+
+(defun mips-goto-label (&optional label)
+  (interactive)
+  (let ((label (or label (read-minibuffer "Go to Label: "))))
+    (beginning-of-buffer)
+    (re-search-forward (format "[ \t]*%s:" label))))
+
+(defun mips-goto-label-at-cursor ()
+  (interactive)
+  (mips-goto-label (symbol-at-point)))
 
 ;;;###autoload
 (define-derived-mode mips-mode prog-mode "MIPS Assembly"

--- a/mips-mode.el
+++ b/mips-mode.el
@@ -28,14 +28,14 @@
   :link '(emacs-commentary-link :tag "Commentary" "ng2-mode"))
 
 (defconst mips-keywords
-  '(;; instructions
+  '(;; Arithmetic insturctions
     "add"
     "sub"
     "addi"
     "addu"
     "subu"
     "addiu"
-    ;;
+    ;; Multiplication/division
     "mult"
     "div"
     "rem"
@@ -44,7 +44,7 @@
     "mfhi"
     "mflo"
     "mul"
-    ;;
+    ;; Bitwise operations
     "not"
     "and"
     "or"
@@ -53,19 +53,19 @@
     "andi"
     "ori"
     "xori"
-    ;;
+    ;; Shifts
     "sll"
     "srl"
     "sra"
     "sllv"
     "srlv"
     "srav"
-    ;;
+    ;; Comparisons
     "slt"
     "sltu"
     "slti"
     "sltiu"
-    ;;
+    ;; Jump/branch
     "j"
     "jal"
     "jr"
@@ -73,7 +73,7 @@
     "beq"
     "bne"
     "syscall"
-    ;;
+    ;; Load/store
     "lui"
     "lb"
     "lbu"
@@ -83,17 +83,34 @@
     "sb"
     "sh"
     "sw"
-    ;;
+    ;; Concurrent load/store
     "ll"
     "sc"
-
-    ;; pseudo instructions;
+    ;; Trap handling
+    "break"
+    "teq"
+    "teqi"
+    "tge"
+    "tgei"
+    "tgeu"
+    "tgeiu"
+    "tlt"
+    "tlti"
+    "tltu"
+    "tltiu"
+    "tne"
+    "tnei"
+    ;; Pseudoinstructions
     "b"
     "bal"
     "bge"
     "bgt"
     "ble"
     "blt"
+    "bgeu"
+    "bleu"
+    "bltu"
+    "bgtu"
     "bgez"
     "blez"
     "bgtz"
@@ -108,18 +125,47 @@
     "move"
     "nop"
     "clear"
-
-    ;; floating point instuctions
+    ;; Deprecated branch-hint pseudoinstructions
+    "beql"
+    "bnel"
+    "bgtzl"
+    "bgezl"
+    "bltzl"
+    "blezl"
+    "bltzall"
+    "bgezall"
+    ;; Floating point instuctions
+    ;; Arithmetic
     "add.s"
-    "sub.s"
-    "mul.s"
-    "div.s"
     "add.d"
+    "sub.s"
     "sub.d"
+    "mul.s"
     "mul.d"
+    "div.s"
     "div.d"
+    ;; Comparison
     "c.lt.s"
     "c.lt.d"
+    "c.gt.s"
+    "c.gt.d"
+    "madd.s"
+    "madd.d"
+    "msub.s"
+    "msub.d"
+    "movt.s"
+    "movt.d"
+    "movn.s"
+    "movn.d"
+    "movz.s"
+    "movz.d"
+    "trunc.w.d"
+    "trunc.w.s"
+    ;; Math
+    "abs.s"
+    "abs.d"
+    "sqrt.s"
+    "sqrt.d"
     ))
 
 (defconst mips-defs


### PR DESCRIPTION
MIPS has so many instructions. I should really go through the MIPS V reference manual index and finalize the list, but that wouldn't even come close to covering the assembler macros.
