### PR TITLE
Fix line indentation on labels with underscores

### DIFF
--- a/mips-mode.el
+++ b/mips-mode.el
@@ -272,7 +272,7 @@
   (save-excursion
     (previous-line)
     (end-of-line)
-    (re-search-backward "^[ \t]*\\w+:")
+    (re-search-backward "^[ \t]*[a-zA-Z][a-zA-Z_0-9]*:")
     (line-number-at-pos)))
 
 (defun mips-indent ()


### PR DESCRIPTION
We already had a nice regex to detect labels in our syntax highlighting code, so let's just reuse that.