### PR TITLE
MIPS indent redux

### DIFF
--- a/mips-mode.el
+++ b/mips-mode.el
@@ -28,241 +28,61 @@
   :link '(url-link :tag "Github" "https://github.com/hlissner/emacs-mips-mode")
   :link '(emacs-commentary-link :tag "Commentary" "ng2-mode"))
 
-(defcustom mips-tab-width tab-width
-  "Width of a tab for `mips-mode'. It is also the opcode column."
-  :tag "Tab width"
-  :group 'mips
-  :type 'integer)
-
-(defcustom mips-operand-offset mips-tab-width
-  "The width of separation between the opcode and the registers/immediate values."
-  :tag "MIPS assembly opcode / operand offset."
-  :group 'mips
-  :type 'integer)
-
-(defcustom mips-base-line 0
-  "The base line from which indentation is started."
-  :tag "Indent base line."
-  :group 'mips
-  :type 'integer)
-
-(defcustom mips-comment-base-line 0
-  "The column to which comments are lined up."
-  :tag "Comment base line."
-  :group 'mips
-  :type 'integer)
-
 (defcustom mips-interpreter "spim"
-  "Path to the mips interpreter executable for running mips code with."
+  "Path to the mips interpreter executable."
   :tag "MIPS Interpreter"
   :group 'mips
   :type 'string)
 
-(defvar mips-keywords
-  '(;; Arithmetic insturctions
-    "add"
-    "sub"
-    "addi"
-    "addu"
-    "subu"
-    "addiu"
-    ;; Multiplication/division
-    "mult"
-    "div"
-    "rem"
-    "multu"
-    "divu"
-    "mfhi"
-    "mflo"
-    "mul"
-    "mulu"
-    "mulo"
-    "mulou"
-    ;; Bitwise operations
-    "not"
-    "and"
-    "or"
-    "nor"
-    "xor"
-    "andi"
-    "ori"
-    "xori"
-    ;; Shifts
-    "sll"
-    "srl"
-    "sra"
-    "sllv"
-    "srlv"
-    "srav"
-    ;; Comparisons
-    "seq"
-    "sne"
-    "sgt"
-    "sgtu"
-    "sge"
-    "sgeu"
-    "slt"
-    "sltu"
-    "slti"
-    "sltiu"
-    ;; Jump/branch
-    "j"
-    "jal"
-    "jr"
-    "jalr"
-    "beq"
-    "bne"
-    "syscall"
-    ;; Load/store
-    "lui"
-    "lb"
-    "lbu"
-    "lh"
-    "lhu"
-    "lw"
-    "lwl"
-    "lwr"
-    "sb"
-    "sh"
-    "sw"
-    "swl"
-    "swr"
-    ;; Concurrent load/store
-    "ll"
-    "sc"
-    ;; Trap handling
-    "break"
-    "teq"
-    "teqi"
-    "tge"
-    "tgei"
-    "tgeu"
-    "tgeiu"
-    "tlt"
-    "tlti"
-    "tltu"
-    "tltiu"
-    "tne"
-    "tnei"
-    "rfe"
-    ;; Pseudoinstructions
-    "b"
-    "bal"
-    "bge"
-    "bgt"
-    "ble"
-    "blt"
-    "bgeu"
-    "bleu"
-    "bltu"
-    "bgtu"
-    "bgez"
-    "blez"
-    "bgtz"
-    "bltz"
-    "bnez"
-    "beqz"
-    "bltzal"
-    "bgezal"
-    "bgtu"
-    "la"
-    "li"
-    "move"
-    "movz"
-    "movn"
-    "nop"
-    "clear"
-    ;; Deprecated branch-hint pseudoinstructions
-    "beql"
-    "bnel"
-    "bgtzl"
-    "bgezl"
-    "bltzl"
-    "blezl"
-    "bltzall"
-    "bgezall"
-    ;; Floating point instuctions
-    ;; Arithmetic
-    "add.s"
-    "add.d"
-    "sub.s"
-    "sub.d"
-    "mul.s"
-    "mul.d"
-    "div.s"
-    "div.d"
-    ;; Comparison
-    "c.lt.s"
-    "c.lt.d"
-    "c.gt.s"
-    "c.gt.d"
-    "madd.s"
-    "madd.d"
-    "msub.s"
-    "msub.d"
-    "movt.s"
-    "movt.d"
-    "movn.s"
-    "movn.d"
-    "movz.s"
-    "movz.d"
-    "trunc.w.d"
-    "trunc.w.s"
-    ;; Conversion
-    "cvt.s.d"
-    "cvt.d.s"
-    ;; Math
-    "abs.s"
-    "abs.d"
-    "sqrt.s"
-    "sqrt.d"
-    ;; Load-store
-    "l.s"
-    "l.d"
-    "s.s"
-    "s.d"))
+(defcustom mips-tab-width tab-width
+  "Width of a tab for `mips-mode'."
+  :tag "Tab width"
+  :group 'mips
+  :type 'integer)
 
-(defvar mips-defs
-  '(".align"
-    ".ascii"
-    ".asciiz"
-    ".byte"
-    ".data"
-    ".double"
-    ".extern"
-    ".float"
-    ".globl"
-    ".half"
-    ".kdata"
-    ".ktext"
-    ".space"
-    ".text"
-    ".word"))
+(defcustom mips-baseline-column 0
+  "Label definitions are aligned to this column."
+  :tag "Indentation baseline."
+  :group 'mips
+  :type 'integer)
 
-(defvar mips-font-lock-defaults
-  `((;; numbers
-     ("\\_<-?[0-9]+\\>" . font-lock-constant-face)
-     ;; stuff enclosed in "
-     ("\"\\.\\*\\?" . font-lock-string-face)
-     ;; labels
-     ("[a-zA-Z_0-9]*:" . font-lock-function-name-face)
-     (,(regexp-opt mips-keywords 'words) . font-lock-keyword-face)
-     ;; coprocessor load-store instructions
-     ("[sl]wc[1-9]" . font-lock-keyword-face)
-     (,(regexp-opt mips-defs) . font-lock-preprocessor-face)
-     ;; registers
-     ("$\\(f?[0-2][0-9]\\|f?3[01]\\|[ft]?[0-9]\\|[vk][01]\\|a[0-3]\\|s[0-7]\\|[gsf]p\\|ra\\|at\\|zero\\)" . font-lock-type-face)
-     ;; ("$\\([a-z0-9]\\{2\\}\\|zero\\)" . font-lock-constant-face)
-     ;; special characters
-     (":\\|,\\|;\\|{\\|}\\|=>\\|@\\|\\$\\|=" . font-lock-builtin-face))))
+(defcustom mips-operator-column tab-width
+  "Operators and directives are indented to this column."
+  :tag "Operator column."
+  :group 'mips
+  :type 'integer)
 
-;;
+(defcustom mips-operands-column tab-width
+  "Operands such as registers and label references are indented
+to this column."
+  :tag "Register/reference column."
+  :group 'mips
+  :initialize (lambda (s v) (set-default s (* 2 mips-operator-column)))
+  :type 'integer)
+
+(defcustom mips-comments-column 30
+  "Comments are indented to this column."
+  :tag "Comment column."
+  :group 'mips
+  :type 'integer)
+
+(defcustom mips-cycle-indent t
+  "When non-nil, point jumps to the next imporatnt column when
+  indenting. Can be used to loop through the various elements of
+  a statement. "
+  :tag "Cycle indent."
+  :group 'mips
+  :type 'boolean)
+
+;;;
+
 (defun mips--interpreter-buffer-name ()
   "Return a buffer name for the preferred mips interpreter"
   (format "*%s*" mips-interpreter))
 
 (defun mips--interpreter-file-arg ()
-  "Return the appropriate argument to accept a file for the current mips interpreter"
+  "Return the appropriate argument to accept a file for the
+current mips interpreter"
   (cond ((equal mips-interpreter "spim") "-file")))
 
 (defun mips--last-label-line ()
@@ -273,131 +93,9 @@
     (re-search-backward mips-re-label)
     (line-number-at-pos)))
 
-;;; INDENTATION LOGIC
-
-(defvar mips-re-label "^[ \t]*[a-zA-Z_0-9]*:[ \t]?*")
-
-(defvar mips-re-label-instruction "^\\([ \t]*[a-zA-Z0-9_]*:?[ \t]+\\)[a-zA-Z]+[^\n]")
-
-(defvar mips-re-directive "^[ \t]?+\\.")
-
-(defvar mips-re-comment "^[ \t]?+#")
-
-(defun mips-line ()
-  (thing-at-point 'line t))
-
-(defun mips-line-label-p ()
-  (string-match-p mips-re-label (mips-line)))
-
-(defun mips-short-label-p ()
-  (let* ((line (mips-line)) (pos (string-match ":" line)))
-    (< (length (subseq line 0 pos)) mips-tab-width)))
-
-(defun mips-mark-before-indent-column-p ()
-  (< (current-column) mips-tab-width))
-
-(defun mips-line-has-opcode-p ()
-  (string-match-p mips-re-label-instruction (mips-line)))
-
-(defun mips-line-has-register-p ()
-  (string-match "\\$" (mips-line)))
-
-(defun mips-empty-line-p ()
-  (string-match-p "^[ \t]+$" (mips-line)))
-
-(defun mips-operand-column ()
-  (+ mips-operand-offset mips-tab-width))
-
-;; indent
-(defun mips-indent ()
-  (interactive)
-  (when (or (eobp) (and (bobp) (eobp)))
-    (open-line 1))
-  (cond ((mips-line-comment-p)
-         (mips-indent-comment))
-        ((mips-line-directive-p)
-         (mips-indent-directive))
-        ((mips-line-label-p)
-         (mips-indent-label))
-        (t (mips-indent-instruction))))
-
-;; comment
-(defun mips-line-comment-p ()
-  (string-match-p mips-re-comment (mips-line)))
-
-(defun mips-indent-comment ()
-  (indent-line-to mips-comment-base-line))
-
-;; directive
-(defun mips-line-directive-p ()
-  (string-match-p mips-re-directive (mips-line)))
-
-(defun mips-indent-directive ()
-  (save-mark-and-excursion
-   (indent-line-to mips-tab-width))
-  (move-to-column (mips-register-column) t))
-
-;; labels, instructions
-(defun mips-indent-label ()
-  (save-mark-and-excursion
-   (indent-line-to mips-base-line))
-  (cond ((and (mips-short-label-p) (mips-line-label-only-p))
-         (move-to-column mips-tab-width t))
-        ((mips-line-label-only-p)
-         (if (eolp)
-           (move-to-column mips-tab-width t)
-           (end-of-line)))
-        ((and (mips-line-has-opcode-p)
-              (mips-short-label-p))
-         (mips-indent-opcode-column))
-        (t (message "Unhandled format or long label."))))
-
-(defun mips-indent-instruction ()
-  (save-mark-and-excursion
-   (indent-line-to mips-tab-width))
-  (cond ((mips-empty-line-p)
-         (move-to-column mips-tab-width t))
-        (t (mips-indent-opcode-column))))
-
-;; opcode
-(defun mips-indent-opcode-column ()
-  (beginning-of-line)
-  (when (mips-line-label-p)
-    (search-forward ":"))
-  (re-search-forward "[\.a-zA-Z]")
-  (backward-char)
-  (pad tab-width 32)
-  (if (mips-line-has-register-p)
-    (mips-indent-operand-column)
-    (progn
-      (move-to-column (mips-operand-column) t)
-      (eol-before-comment))))
-
-;; operands
-(defun mips-indent-operand-column ()
-  (beginning-of-line)
-  (search-forward "$")
-  (backward-char)
-  (pad (mips-register-column) 32)
-  (eol-before-comment))
-
-(defun eol-before-comment ()
-  (let ((comment (string-match "\\#" (mips-line) (current-column))))
-    (if comment
-      (progn
-        (move-to-column comment)
-        (backward-word)
-        (forward-word))
-      (end-of-line))))
-
-(defun pad (column &optional char)
-  (while (< (current-column) column)
-    (insert (or char 32))))
-
-;;;
-
 (defun mips-run-buffer ()
-  "Run the current buffer in a mips interpreter, and display the output in another window"
+  "Run the current buffer in a mips interpreter, and display the
+output in another window"
   (interactive)
   (let ((tmp-file (format "/tmp/mips-%s" (file-name-base))))
     (write-region (point-min) (point-max) tmp-file nil nil nil nil)
@@ -405,7 +103,8 @@
     (delete-file tmp-file)))
 
 (defun mips-run-region ()
-  "Run the current region in a mips interpreter, and display the output in another window"
+  "Run the current region in a mips interpreter, and display the
+output in another window"
   (interactive)
   (let ((tmp-file (format "/tmp/mips-%s" (file-name-base))))
     (write-region (region-beginning) (region-end) tmp-file nil nil nil nil)
@@ -414,8 +113,8 @@
 
 (defun mips-run-file (&optional filename)
   "Run the file in a mips interpreter, and display the output in another window.
-The interpreter will open filename. If filename is nil, it will open the current
-buffer's file"
+The interpreter will open filename. If filename is nil, it will
+open the current buffer's file"
   (interactive)
   (let ((file (or filename (buffer-file-name))))
     (when (buffer-live-p (get-buffer (mips--interpreter-buffer-name)))
@@ -439,6 +138,133 @@ buffer's file"
   "Jump to the label that matches the symbol at point."
   (interactive)
   (mips-goto-label (symbol-at-point)))
+
+;;;;;;;;;;;;;;;;;
+;; INDENTATION ;;
+;;;;;;;;;;;;;;;;;
+
+;; FIXME: tab indenting support is very unstable.
+
+(defvar mips-line-re
+  "\\(?:[ \t]*\\)?\\([a-zA-Z0-9_]*:\\)?\\(?:[ \t]+\\)?\\([\.a-zA-Z0-9_]*\\)?\\(?:[ \t]*\\)\\([^#\n^]+?\\)?\\(?:[ \t]*\\)?\\(#[^\n]*\\)?$"
+  "An (excessive-looking) regexp to match and group possible MIPS
+  assembly statements. Four capture groups will hold the tokens:
+  1. `labeldef' 2. `operator' 3. `operands' 4. `comments'")
+
+(defmacro defpadder (name column matching-group)
+  "Define a function called NAME to indent one column of a
+MIPS assembly statement. Place point at the first non-whitespace
+character of REGEXP MATCHING-GROUP and pad it to COLUMN."
+  `(defun ,name ()
+     (string-match mips-line-re (thing-at-point 'line t))
+     (when (wholenump (match-beginning ,matching-group))
+       (move-to-column (match-beginning ,matching-group))
+       (when (< (current-column) (match-end ,matching-group))
+         (while (/= (current-column) ,column)
+           (if (> (current-column) ,column)
+             (if (member (preceding-char) '(11 32))
+               (delete-backward-char 1)
+               (progn (move-to-column ,column t)
+                      (message "%s bumped into a wall!" ',name)))
+             (insert (if indent-tabs-mode 11 32))))))))
+
+(defpadder mips-labeldef mips-baseline-column 1)
+(defpadder mips-operator mips-operator-column 2)
+(defpadder mips-operands mips-operands-column 3)
+(defpadder mips-comments mips-comments-column 4)
+
+(defun mips-indent ()
+  "Indent line at point and cycle the cursor."
+  (interactive)
+  (save-mark-and-excursion
+   (mips-labeldef) (mips-operator)
+   (mips-operands) (mips-comments))
+  (when mips-cycle-indent
+    (mips-cycle-cursor)))
+
+(defun mips-dedent ()
+  (interactive)
+  (beginning-of-line)
+  (skip-chars-forward " \t")
+  (while (not (bolp))
+    (if (member (preceding-char) '(11 32))
+      (delete-backward-char 1 nil))))
+
+(defun mips-cycle-cursor ()
+  (cond ((or (bolp) (< (current-column) mips-operator-column))
+         (move-to-column mips-operator-column t))
+        ((< (current-column) mips-operands-column)
+         (move-to-column mips-operands-column t))
+        ((< (current-column) mips-comments-column)
+         (move-to-column mips-comments-column t))
+        ((eolp) (beginning-of-line))
+        (t (end-of-line))))
+
+;;;;;;;;;;;;;
+;; FONTIFY ;;
+;;;;;;;;;;;;;
+
+(defvar mips-font-lock-keywords
+  '( ;; Arithmetic insturctions
+    "add" "sub" "addi" "addu" "subu" "addiu"
+    ;; Multiplication/division
+    "mult" "div" "rem" "multu" "divu" "mfhi" "mflo" "mul" "mulu" "mulo" "mulou"
+    ;; Bitwise operations
+    "not" "and" "or" "nor" "xor" "andi" "ori" "xori"
+    ;; Shifts
+    "sll" "srl" "sra" "sllv" "srlv" "srav"
+    ;; Comparisons
+    "seq" "sne" "sgt" "sgtu" "sge" "sgeu" "slt" "sltu" "slti" "sltiu"
+    ;; Jump/branch
+    "j" "jal" "jr" "jalr" "beq" "bne" "syscall"
+    ;; Load/store
+    "lui" "lb" "lbu" "lh" "lhu" "lw" "lwl" "lwr" "sb" "sh" "sw" "swl" "swr"
+    ;; Concurrent load/store
+    "ll" "sc"
+    ;; Trap handling
+    "break" "teq" "teqi" "tge" "tgei" "tgeu" "tgeiu" "tlt" "tlti" "tltu" "tltiu" "tne" "tnei" "rfe"
+    ;; Pseudoinstructions
+    "b" "bal" "bge" "bgt" "ble" "blt" "bgeu" "bleu" "bltu" "bgtu" "bgez" "blez" "bgtz" "bltz" "bnez"
+    "beqz" "bltzal" "bgezal" "bgtu" "la" "li" "move" "movz" "movn" "nop" "clear"
+    ;; Deprecated branch-hint pseudoinstructions
+    "beql" "bnel" "bgtzl" "bgezl" "bltzl" "blezl" "bltzall" "bgezall"
+    ;; Floating point instuctions
+    ;; Arithmetic
+    "add.s" "add.d" "sub.s" "sub.d" "mul.s" "mul.d" "div.s" "div.d"
+    ;; Comparison
+    "c.lt.s" "c.lt.d" "c.gt.s" "c.gt.d" "madd.s" "madd.d" "msub.s" "msub.d" "movt.s" "movt.d"
+    "movn.s" "movn.d" "movz.s" "movz.d" "trunc.w.d" "trunc.w.s"
+    ;; Conversion
+    "cvt.s.d" "cvt.d.s"
+    ;; Math
+    "abs.s" "abs.d" "sqrt.s" "sqrt.d"
+    ;; Load-store
+    "l.s" "l.d" "s.s" "s.d"))
+
+(defvar mips-font-lock-directives
+  '(".align" ".ascii" ".asciiz" ".byte" ".data" ".double" ".extern" ".float"
+    ".globl" ".half" ".kdata" ".ktext" ".space" ".text" ".word"))
+
+(defvar mips-font-lock-defaults
+  `((;; numbers
+     ("\\_<-?[0-9]+\\>" . font-lock-constant-face)
+     ;; stuff enclosed in "
+     ("\"\\.\\*\\?" . font-lock-string-face)
+     ;; labels
+     ("[a-zA-Z_0-9]*:" . font-lock-function-name-face)
+     (,(regexp-opt mips-font-lock-keywords 'words) . font-lock-keyword-face)
+     ;; coprocessor load-store instructions
+     ("[sl]wc[1-9]" . font-lock-keyword-face)
+     (,(regexp-opt mips-font-lock-directives) . font-lock-preprocessor-face)
+     ;; registers
+     ("$\\(f?[0-2][0-9]\\|f?3[01]\\|[ft]?[0-9]\\|[vk][01]\\|a[0-3]\\|s[0-7]\\|[gsf]p\\|ra\\|at\\|zero\\)" . font-lock-type-face)
+     ;; ("$\\([a-z0-9]\\{2\\}\\|zero\\)" . font-lock-constant-face)
+     ;; special characters
+     (":\\|,\\|;\\|{\\|}\\|=>\\|@\\|\\$\\|=" . font-lock-builtin-face))))
+
+;;;;;;;;;;
+;; MODE ;;
+;;;;;;;;;;
 
 (defvar mips-mode-map
   (let ((map (make-sparse-keymap)))

--- a/mips-mode.el
+++ b/mips-mode.el
@@ -150,8 +150,8 @@ open the current buffer's file"
   ;; trigger it), It's only called by `mips-mode', and can be removed
   ;; as soon as tabs work properly.
   (save-excursion
-    (save-match-data (re-search-forward "^\t" nil t))
-    (when (and (match-data) (y-or-n-p "Sanitize (untabify/re-indent) buffer? "))
+    (when (and (re-search-forward "^\t" nil t)
+               (y-or-n-p "Sanitize (untabify/re-indent) buffer? "))
       (mips-indent-region (point-min) (point-max)))))
 
 ;;;;;;;;;;;;;;;;;

--- a/mips-mode.el
+++ b/mips-mode.el
@@ -248,7 +248,8 @@ until COLUMN."
 (defun mips-auto-indent ()
   (when (and mips-auto-indent
              (eq major-mode 'mips-mode)
-             (not (mips-comment-line-p)))
+             (and (stringp (mips-line))
+                  (not (mips-comment-line-p))))
     (mips-align-all-columns)))
 
 (defun mips-dedent ()

--- a/mips-mode.el
+++ b/mips-mode.el
@@ -201,7 +201,9 @@ until COLUMN."
   "Indent MIPS assembly line at point and run hook."
   (interactive)
   (if (mips-comment-line-p)
-    (mips-dedent)
+    (if suppress-hook ;; called on a region
+      (mips-dedent)
+      (mips-cycle-indent))
     (save-mark-and-excursion
      (mips-pad-rxg mips-baseline-column 1)
      (mips-pad-rxg mips-operator-column 2)
@@ -233,16 +235,23 @@ until COLUMN."
   (deactivate-mark)
   (indent-line-to mips-baseline-column))
 
-(defun mips-cycle-point ()
-  "Move point to the next \"significant\" column on line."
+(defun mips-cycle (func &rest args)
   (cond ((or (bolp) (< (current-column) mips-operator-column))
-         (move-to-column mips-operator-column t))
+         (apply func mips-operator-column args))
         ((< (current-column) mips-operands-column)
-         (move-to-column mips-operands-column t))
+         (apply func mips-operands-column args))
         ((< (current-column) mips-comments-column)
-         (move-to-column mips-comments-column t))
-        ((eolp) (beginning-of-line))
+         (apply func mips-comments-column args))
+        ((eolp) (apply func mips-baseline-column args))
         (t (end-of-line))))
+
+(defun mips-cycle-indent ()
+  "Move indentation to the next \"significant\" column."
+  (mips-cycle #'indent-line-to))
+
+(defun mips-cycle-point ()
+  "Move point to the next \"significant\" column."
+  (mips-cycle #'move-to-column t))
 
 ;;;;;;;;;;;;;
 ;; FONTIFY ;;

--- a/mips-mode.el
+++ b/mips-mode.el
@@ -177,25 +177,24 @@ open the current buffer's file"
   "Return true if line at point is comment-only."
   (string-match-p mips-comment-line-re (mips-line)))
 
-(defmacro mips-pad-rxg (column group)
+(defun mips-pad-rxg (column group)
   "Match a MIPS assembly statement using `mips-line-re' and trim,
 pad or backward-delete string segment in matching group GROUP
 until COLUMN."
-  `(progn
-     (string-match mips-line-re (mips-line))
-     (when (wholenump (match-beginning ,group))
-       (move-to-column (match-beginning ,group))
-       (when (< (current-column) (match-end ,group))
-         (while (/= (current-column) ,column)
-           (if (< (current-column) ,column)
-             (insert mips-indent-character)
-             (if (member (preceding-char) mips-wp-char)
-               (delete-backward-char 1)
-               (progn (message "Bumped into a wall at column %s!" (current-column))
-                      (insert mips-indent-character) ;; pad one whitespace
-                      (move-to-column ,column t)     ;; and bail out forward.
-                      (while (member (char-after) mips-wp-char)
-                        (delete-forward-char 1))))))))))
+  (string-match mips-line-re (mips-line))
+  (when (wholenump (match-beginning group))
+    (move-to-column (match-beginning group))
+    (when (< (current-column) (match-end group))
+      (while (/= (current-column) column)
+        (if (< (current-column) column)
+          (insert mips-indent-character)
+          (if (member (preceding-char) mips-wp-char)
+            (delete-backward-char 1)
+            (progn (message "Bumped into a wall at column %s!" (current-column))
+                   (insert mips-indent-character) ;; pad one whitespace
+                   (move-to-column column t)     ;; and bail out forward.
+                   (while (member (char-after) mips-wp-char)
+                     (delete-forward-char 1)))))))))
 
 (defun mips-indent-line (&optional suppress-hook)
   "Indent MIPS assembly line at point and run hook."
@@ -241,8 +240,7 @@ until COLUMN."
          (apply func mips-operands-column args))
         ((< (current-column) mips-comments-column)
          (apply func mips-comments-column args))
-        ((eolp) (apply func mips-baseline-column args))
-        (t (end-of-line))))
+        (t (apply func mips-baseline-column args))))
 
 (defun mips-cycle-indent ()
   "Move indentation to the next \"significant\" column."

--- a/mips-mode.el
+++ b/mips-mode.el
@@ -194,7 +194,7 @@ until COLUMN."
             (delete-backward-char 1)
             (progn (message "Bumped into a wall at column %s!" (current-column))
                    (insert mips-indent-character) ;; pad one whitespace
-                   (move-to-column column t)     ;; and bail out forward.
+                   (move-to-column column t)      ;; and bail out forward.
                    (while (member (char-after) mips-wp-char)
                      (delete-forward-char 1)))))))))
 
@@ -227,13 +227,21 @@ until COLUMN."
                  (not (eobp)))
        (funcall indent-line-function t)
        (forward-line)))
-    (delete-trailing-whitespace)))
+    (delete-trailing-whitespace start end)))
 
 (defun mips-dedent ()
   "Dedent line to the baseline."
   (interactive)
   (deactivate-mark)
   (indent-line-to mips-baseline-column))
+
+(defun mips-newline ()
+  "`newline' for MIPS assembly." ;; to handle comment lines
+  (interactive)
+  (if (mips-comment-line-p)
+    (progn (open-line 1) (forward-line))
+    (newline)
+    (mips-indent-line)))
 
 (defun mips-cycle (func &rest args)
   (cond ((or (bolp) (< (current-column) mips-operator-column))
@@ -321,6 +329,7 @@ until COLUMN."
 (defvar mips-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "<backtab>") #'mips-dedent)
+    (define-key map (kbd "RET")       #'mips-newline)
     (define-key map (kbd "C-c C-c")   #'mips-run-buffer)
     (define-key map (kbd "C-c C-r")   #'mips-run-region)
     (define-key map (kbd "C-c C-l")   #'mips-goto-label-at-cursor)

--- a/mips-mode.el
+++ b/mips-mode.el
@@ -86,8 +86,8 @@ to this column."
   :group 'mips
   :set (lambda (s v)
          (set-default s v)
-         (if v (add-hook 'post-self-insert-hook #'mips-auto-indent)
-             (remove-hook 'post-self-insert-hook #'mips-auto-indent)))
+         (if v (add-hook 'post-command-hook #'mips-auto-indent)
+             (remove-hook 'post-command--hook #'mips-auto-indent)))
   :type 'boolean)
 
 (defun mips--interpreter-buffer-name ()

--- a/mips-mode.el
+++ b/mips-mode.el
@@ -241,7 +241,7 @@ until COLUMN."
   "`newline' for MIPS assembly." ;; to handle comment lines
   (interactive)
   (cond ((mips-comment-line-p) (split-line) (forward-line))
-        (t (newline) (mips-indent-line))))
+        (t (newline) (mips-indent-line) (back-to-indentation))))
 
 (defun mips-cycle (func &rest args)
   (cond ((or (bolp) (< (current-column) mips-operator-column))

--- a/mips-mode.el
+++ b/mips-mode.el
@@ -201,8 +201,7 @@ until COLUMN."
   "Indent MIPS assembly line at point and run hook."
   (interactive)
   (if (mips-comment-line-p)
-    (if suppress-hook ;; called on a region
-      (mips-dedent)
+    (unless suppress-hook
       (mips-cycle-indent))
     (save-mark-and-excursion
      (mips-pad-rxg mips-baseline-column 1)

--- a/mips-mode.el
+++ b/mips-mode.el
@@ -158,10 +158,12 @@ open the current buffer's file"
 ;; INDENTATION ;;
 ;;;;;;;;;;;;;;;;;
 (defvar mips-line-re
-  "\\(?:[ \t]*\\)?\\([a-zA-Z0-9_]*:\\)?\\(?:[ \t]+\\)?\\([\.a-zA-Z0-9_]*\\)?\\(?:[ \t]*\\)\\([^#\n^]+?\\)?\\(?:[ \t]*\\)?\\(#[^\n]*\\)?$"
-  "An (excessive) regexp to match MIPS assembly statements. After
-  matching, `match-data' will hold four matching groups:
-  1. `labeldef' 2. `operator' 3. `operands' 4. `comments'")
+  (concat
+   "\\(?:[ \t]*\\)?\\([a-zA-Z0-9_]*:\\)?"      ;; label definition
+   "\\(?:[ \t]*\\)?\\([\.a-zA-Z0-9_]*\\)?"     ;; opcode/operator
+   "\\(?:[ \t]*\\)?\\(\".*\"\\|[^#\n^]+?\\)?"  ;; operands/registers
+   "\\(?:[ \t]*\\)?\\(#[^\n]*\\)?$")           ;; comments
+  "An (excessive) regexp to match MIPS assembly statements.")
 
 (defvar mips-comment-line-re "^[ t]*#[^\n]*"
   "Regexp to match comment-only lines.")

--- a/mips-mode.el
+++ b/mips-mode.el
@@ -187,15 +187,15 @@ until COLUMN."
        (move-to-column (match-beginning ,group))
        (when (< (current-column) (match-end ,group))
          (while (/= (current-column) ,column)
-           (if (> (current-column) ,column)
+           (if (< (current-column) ,column)
+             (insert mips-indent-character)
              (if (member (preceding-char) mips-wp-char)
                (delete-backward-char 1)
-               (progn (message "Bumped into a wall at %s!"
-                               (current-column))
-                      (move-to-column ,column t)
+               (progn (message "Bumped into a wall at column %s!" (current-column))
+                      (insert mips-indent-character) ;; pad one whitespace
+                      (move-to-column ,column t)     ;; and bail out forward.
                       (while (member (char-after) mips-wp-char)
-                        (delete-forward-char 1))))
-             (insert mips-indent-character)))))))
+                        (delete-forward-char 1))))))))))
 
 (defun mips-indent-line (&optional suppress-hook)
   "Indent MIPS assembly line at point and run hook."


### PR DESCRIPTION
Hi Henrik, 

I worked on the thing some more to make it DWIMer (and went wild with `re-builder`in the process). I also added a `mips-indent-region`, in part to sidestep some ugliness when the mark is not deactivated. It just applies `mips-indent-line` as it goes, so it's not all that blazing when indenting https://github.com/alexdantas/arkamips, for example, but at least there will be stuff to optimize if speed becomes a concern. 

I guess I'm saving proper tab support for later, and I'm wondering if you mind my moving&singe-lining of the keywords.

Bye,